### PR TITLE
seat details fetching done

### DIFF
--- a/Order/routers/ticket_locking.py
+++ b/Order/routers/ticket_locking.py
@@ -94,6 +94,17 @@ def force_unlock_seat(
             detail="Seat not found or not locked by this user"
         )
 
+@router.get("/event-seat-status/{event_id}")
+def get_event_seat_status(
+    event_id: int,
+    session: Session = Depends(get_session)
+):
+    """
+    Get all seat statuses (booked, locked, available) for an event.
+    Returns seat states for visualization on the seating page.
+    """
+    return TicketLockingService.get_event_seat_status(session, event_id)
+
 @router.get("/stats/{event_id}")
 def get_locking_stats(
     event_id: int,


### PR DESCRIPTION
This pull request introduces a new API endpoint to retrieve the real-time status of all seats for a given event, including which seats are booked and which are currently locked. This is primarily aimed at supporting visualization of seat availability on the event seating page. The main logic for collecting this data is implemented in the service layer, aggregating information from both the database and Redis.

**New event seat status API:**

* Added a new GET endpoint `/event-seat-status/{event_id}` in `ticket_locking.py` to return the booked and locked seats for a given event, intended for use by the seating visualization UI.

**Service logic for seat status aggregation:**

* Implemented `get_event_seat_status` in `ticket_locking_service.py`, which:
  - Collects all booked seats by querying user tickets for the event.
  - Scans Redis for all currently locked (and unexpired) seats.
  - Returns both lists in a structured format for frontend consumption.